### PR TITLE
removed trailing commas

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "contributors": [
     "Pablo Castaneda",
-    "Juan Sanchez",
+    "Juan Sanchez"
   ],
   "license": "MIT",
   "devDependencies": {
@@ -38,7 +38,7 @@
     "glob": "^4.0.5"
   },
   "keywords": [
-    "ember-addon", "mocha", "coffeescript",
+    "ember-addon", "mocha", "coffeescript"
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Using node 0.12 I was getting errors complaining about trailing commas in the arrays in package.json. This fixed the issue for me.